### PR TITLE
Added queue management to IMAP import/export

### DIFF
--- a/imapexport.py
+++ b/imapexport.py
@@ -14,10 +14,8 @@ Example Usage:
 import sys
 import json
 import argparse
-import requests
 import datim.datimimap
 import datim.datimimapexport
-from import_manager import has_existing_import
 import common
 
 
@@ -48,31 +46,17 @@ parser.add_argument(
 parser.add_argument('--version', action='version', version='%(prog)s v' + common.APP_VERSION)
 args = parser.parse_args()
 ocl_env_url = args.env if args.env else args.env_url
-
-# Display debug output
-if args.verbosity > 1:
-    print args
-
-# Exit if import is already in process
-# TODO: Fix this so that it is automatically skipped if not run in an async environment
-# if has_existing_import(args.country_code):
-#     response = {
-#             'status_code': 409,
-#             'result': 'There is an import already in progress for this country code'
-#         }
-#     print json.dumps(response)
-#     sys.exit(1)
-
-# Pre-process input parameters
 country_org = 'DATIM-MOH-%s-%s' % (args.country_code, args.period)
 
-# Debug output
+# Display debug output
 if args.verbosity:
-    print('\n\n' + '*' * 100)
-    print('** [EXPORT] Country Code: %s, Org: %s, Format: %s, Period: %s, Version: %s, Exclude Empty Maps: %s, Verbosity: %s, OCL Env: %s' % (
+    if args.verbosity > 1:
+        print args
+    print '\n\n' + '*' * 100
+    print '** [EXPORT] Country Code: %s, Org: %s, Format: %s, Period: %s, Version: %s, Exclude Empty Maps: %s, Verbosity: %s, OCL Env: %s' % (
         args.country_code, country_org, args.format, args.period, args.country_version,
-        str(args.exclude_empty_maps), str(args.verbosity)), ocl_env_url)
-    print('*' * 100)
+        str(args.exclude_empty_maps), str(args.verbosity), ocl_env_url)
+    print '*' * 100
 
 # Generate the IMAP export
 datim_imap_export = datim.datimimapexport.DatimImapExport(
@@ -82,10 +66,11 @@ try:
     imap = datim_imap_export.get_imap(
         period=args.period, version=args.country_version, country_org=country_org,
         country_code=args.country_code)
-except (requests.exceptions.HTTPError, Exception) as e:
+except Exception as err:
     output = {
         'status': 'Error',
-        'message': str(e)
+        'type': err.__class__.__name__,
+        'message': str(err)
     }
     print json.dumps(output)
     sys.exit(1)

--- a/imapimport.py
+++ b/imapimport.py
@@ -131,6 +131,7 @@ try:
 except Exception as err:
     output_json["status"] = "Error"
     output_json["message"] = str(err)
+    output_json['type'] = err.__class__.__name__
 else:
     if args.test_mode:
         output_json["status"] = "Test"

--- a/mohcodelistdiff.py
+++ b/mohcodelistdiff.py
@@ -1,0 +1,42 @@
+import csv
+import pprint
+from deepdiff import DeepDiff
+
+# FY18: sfk9cyQSUyi
+# FY19: OBhi1PUW3OL
+# FY20: QSodwF4YG9a
+
+# periods = ['FY18', 'FY19', 'FY20']
+periods = ['FY19', 'FY20']
+
+for period in periods:
+    ocl_filename = 'ocl_moh_%s.csv' % period
+    dhis2_filename = 'dhis2_moh_%s.csv' % period
+
+    ocl_codelist = {}
+    with open(ocl_filename) as ocl_file:
+        ocl_reader = csv.DictReader(ocl_file)
+        for row in ocl_reader:
+            row_id = '%s.%s' % (row['dataelementuid'], row['categoryoptioncombouid'])
+            ocl_codelist[row_id] = row
+            # ocl_codelist.append(row)
+
+    dhis2_codelist = {}
+    with open(dhis2_filename) as dhis2_file:
+        dhis2_reader = csv.DictReader(dhis2_file)
+        for row in dhis2_reader:
+            row_id = '%s.%s' % (row['dataelementuid'], row['categoryoptioncombouid'])
+            dhis2_codelist[row_id] = row
+            # dhis2_codelist.append(row)
+
+    # Sort lists
+    # ocl_codelist_sorted = sorted(ocl_codelist, key = lambda i: (i['id']))
+    # dhis2_codelist_sorted = sorted(dhis2_codelist, key = lambda i: (i['id']))
+    # ddiff = DeepDiff(dhis2_codelist_sorted, ocl_codelist_sorted)
+
+    ddiff = DeepDiff(dhis2_codelist, ocl_codelist)
+    print '%s:' % period
+    pprint.pprint(ddiff)
+    print '\n\n'
+
+    # print period, len(ocl_codelist), len(dhis2_codelist)

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,7 +26,7 @@ kombu==4.3.0
 lazy-object-proxy==1.3.1
 mccabe==0.6.1
 monotonic==1.5
-ocldev==0.1.77
+ocldev==0.1.78
 pathlib2==2.3.5
 pprint==0.1
 pylint==1.9.2


### PR DESCRIPTION
IMAP import and export scripts now raise a `datim.datimimapimport.ImapCountryLockedForPeriodError` exception if a bulk import is already underway for the same country and period. For example, if an IMAP for Ethiopia FY19 was submitted to OCL staging and its bulk import status is either `PENDING` or `STARTED`, then the IMAP import and export scripts will raise `ImapCountryLockedForPeriodError` and prevent a new import/export from starting until the one in OCL's bulk import queue has finished.